### PR TITLE
Adds UITest file to demos

### DIFF
--- a/UITest.swift
+++ b/UITest.swift
@@ -65,9 +65,9 @@ extension GREYElementInteraction {
 		performAction(GREYActions.actionForTap())
 	}
 
-  func swipeLeft() {
-    performAction(GREYActions.actionForSwipeSlowInDirection(GREYDirection.Left))
-  }
+	func swipeLeft() {
+		performAction(GREYActions.actionForSwipeSlowInDirection(GREYDirection.Left))
+	}
 
 	func assertIsVisible() {
 		assertWithMatcher(GREYMatchers.matcherForSufficientlyVisible())

--- a/UITest.swift
+++ b/UITest.swift
@@ -1,0 +1,92 @@
+import XCTest
+
+// This code allows a nicer API around [EarlGrey](https://github.com/google/EarlGrey). 
+// Let your `XCTest` class implement this protocol, and then use the protocol extensions. For example:
+// `onViewWith(accesssibilityLabel: "doneButton").tap()`
+protocol UITest {
+
+	var earlGrey: EarlGreyImpl { get }
+
+}
+
+extension UITest {
+
+	func onViewWith(accessibilityIdentifier accessibilityIdentifier: String) -> GREYElementInteraction {
+		return earlGrey.selectElementWith(accessibilityIdentifier: accessibilityIdentifier)
+	}
+	
+	func onViewsWith(accessibilityIdentifier accessibilityIdentifier: String) -> GREYElementInteraction {
+		return earlGrey.selectElementWith(accessibilityIdentifier: accessibilityIdentifier)
+	}
+
+	func onViewWith(accessibilityLabel accessibilityLabel: String) -> GREYElementInteraction {
+		return earlGrey.selectElementWith(accessibilityLabel: accessibilityLabel)
+	}
+
+	func assertVisibleViewWith(accessibilityIdentifier: String) {
+		earlGrey.selectElementWith(accessibilityIdentifier: accessibilityIdentifier).assertIsVisible()
+	}
+	
+}
+
+//MARK: - 
+
+extension EarlGreyImpl {
+	
+	func selectElementWith(accessibilityLabel accessibilityLabel: String) -> GREYElementInteraction {
+		return selectElementWithMatcher(GREYMatchers.matcherForAccessibilityLabel(accessibilityLabel))
+	}
+
+	func selectElementWith(accessibilityIdentifier accessibilityIdentifier: String) -> GREYElementInteraction {
+		return selectElementWithMatcher(GREYMatchers.matcherForAccessibilityID(accessibilityIdentifier))
+	}
+
+	func selectElementWith(text text: String) -> GREYElementInteraction {
+		return selectElementWithMatcher(GREYMatchers.matcherForText(text))
+	}
+
+	func selectElementWith(buttonTitle buttonTitle: String) -> GREYElementInteraction {
+		return selectElementWithMatcher(GREYMatchers.matcherForButtonTitle(buttonTitle))
+	}
+	
+	func tapTabBarItemWith(accesibilityLabel label: String) {
+		EarlGrey().selectElementWithMatcher(grey_accessibilityLabel(label)).inRoot(grey_kindOfClass(UITabBar.classForCoder())).atIndex(0).performAction(grey_tap())
+	}
+}
+
+extension GREYElementInteraction {
+
+	func tap() {
+		performAction(GREYActions.actionForTap())
+	}
+	
+	func doubleTap() {
+		performAction(GREYActions.actionForTap())
+		performAction(GREYActions.actionForTap())
+	}
+
+  func swipeLeft() {
+    performAction(GREYActions.actionForSwipeSlowInDirection(GREYDirection.Left))
+  }
+
+	func assertIsVisible() {
+		assertWithMatcher(GREYMatchers.matcherForSufficientlyVisible())
+	}
+
+	func assertText(matches string: String) {
+		assertWithMatcher(GREYMatchers.matcherForText(string))
+	}
+	
+	func type(text text:String) {
+		performAction(GREYActions.actionForTypeText(text))
+	}
+	
+	func getText(inout text: String) {
+		performAction(GREYActionBlock.actionWithName("get text",
+			constraints: grey_respondsToSelector(Selector("text")),
+			performBlock: { element, errorOrNil -> Bool in
+				text = element.text
+				return true
+		}))
+	}
+}

--- a/UITest.swift
+++ b/UITest.swift
@@ -29,8 +29,6 @@ extension UITest {
 	
 }
 
-//MARK: - 
-
 extension EarlGreyImpl {
 	
 	func selectElementWith(accessibilityLabel accessibilityLabel: String) -> GREYElementInteraction {


### PR DESCRIPTION
#### This PR adds

A wrapper around [EarlGrey](https://github.com/google/EarlGrey) to make UI tests more fluent

#### Considerations and implementation

I will add some demo implementations soon, but for now just putting this here so I don't forget about it. EarlGrey is powerful but the API sucks and is very tied to EarlGrey. The aim of this wrapper is to make tests more fluent and less implementation-oriented. Here's an example of how these wrappers help:

before:
```swift
let earlGrey = EarlGreyImpl()
earlGrey.selectElementWithMatcher(GREYMatchers.matcherForAccessibilityLabel("doneButton"))
    .assertWithMatcher(GREYMatchers.matcherForText("Done"))
```

after:
```swift
onViewWith(accessibilityIdentifier: "doneButton").assertText(matches: "Done")
```

#### Test(s) added 

No, but I will add a bigger and better demo soon!

#### Screenshots

no UI

#### Paired with 

@ the scout iOS team
