### PR TITLE
Adding tracking for images to make smooth transition

### DIFF
--- a/ARImageTrackingExamples/ARImageTrackingExamples/ViewModels/ARViewModel.swift
+++ b/ARImageTrackingExamples/ARImageTrackingExamples/ViewModels/ARViewModel.swift
@@ -8,12 +8,22 @@ class ARViewModel {
         guard let referenceImages = ARReferenceImage.referenceImages(inGroupNamed: "AR Resources", bundle: nil) else {
             fatalError("Missing expected asset catalog resources.")
         }
+        let configuration = ARImageTrackingConfiguration()
+        configuration.trackingImages = referenceImages
+        configuration.maximumNumberOfTrackedImages = 2
+        return configuration
+    }
+
+    func worldTrackingWithImageDetection() -> ARConfiguration {
+        guard let referenceImages = ARReferenceImage.referenceImages(inGroupNamed: "AR Resources", bundle: nil) else {
+            fatalError("Missing expected asset catalog resources.")
+        }
         let configuration = ARWorldTrackingConfiguration()
         configuration.detectionImages = referenceImages
         configuration.maximumNumberOfTrackedImages = 2
         return configuration
     }
-
+    
     func image(correspondingTo referenceImage: ARReferenceImage) -> UIImage? {
         guard let referenceImageName = referenceImage.name,
             let correspondingImageName = assets[referenceImageName] else {


### PR DESCRIPTION
Found out that when using ImageTracking Configuration instead of World Tracking with image detection it changes how the experience looks. 

So i wanted to make the code available for both types of tracking. And I set this demo to use image tracking instead of world configuration. 

**Image Tracking** Tracks images on 2D only and does not use the plane detection part, meaning saves CPU and works even when the phone and user are on moving targets like a train. The anchors gets deleted automatically once it stops tracking. Allowing to make the experience really about just the image being tracked. 

![2s038q 1](https://user-images.githubusercontent.com/5808608/51742423-02784680-209a-11e9-9613-0b4f24dda710.gif)


**World Tracking with Image Detection** Now when using World tracking and image detection, it detects where the image is but it does not TRACK it. But it can detect an image on 3D environment and creates a 3D anchor for said image only once, meaning we would have to personally decide when and if we want to delete the AR Content when needed. Image detection is recommend to not pin AR content to images but to use images as a starting point to create an AR experience. Since this uses plane detection, it changes depending on how fast the phone gets moved and uses more CPU power. 

![2s02oe](https://user-images.githubusercontent.com/5808608/51741910-787bae00-2098-11e9-80f8-5231cbf4e03e.gif)